### PR TITLE
Customizeable Reach page link text ("learn more")

### DIFF
--- a/_data/poi_reach/africa.yaml
+++ b/_data/poi_reach/africa.yaml
@@ -10,6 +10,7 @@
   quote: "MapAfrica allows us to present our investments and results in a simple way, bringing us closer to the people we serve."
   quote-author: Simon Mizrahi, AfDB Director
   url: http://mapafrica.afdb.org/
+  urlText:
 
 - name: Burkina Faso
   id: burkina-faso
@@ -22,6 +23,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 12.2472489
   lon: -1.5556799
 
@@ -36,6 +38,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 15.4461015
   lon: 18.7350005
 
@@ -50,6 +53,7 @@
   quote: "[AMP] will be a one-stop shop of information on aid flows that will improve efficiency in the monitoring and management of external resources that benefit our country."
   quote-author: Nial Kaba, CIV Minister of Economy and Finance
   url:
+  urlText:
   lat: 7.5455351
   lon: -5.547545
 
@@ -64,6 +68,7 @@
   quote: "[Before AMP] different ministries would speak directly with donor partners. Now… to acquire information the unique official source is AMP"
   quote-author: Government Representative
   url:
+  urlText:
   lat: -4.033516
   lon: 21.7500605
 
@@ -78,6 +83,7 @@
   quote: Development Gateway builds trust and ability among individuals interested in using AMP.
   quote-author: Government of Ethiopia Representative
   url:
+  urlText:
   lat: 9.1491755
   lon: 40.499395
 
@@ -92,6 +98,7 @@
   quote:
   quote-author:
   url: www.openschoolskenya.org
+  urlText:
   lat: -1.3167
   lon: 36.7833
 
@@ -106,6 +113,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: -18.7792398
   lon: 46.8344597
 
@@ -120,6 +128,7 @@
   quote: "...the Public Portal of the AMP marks yet another milestone in the open development agenda, as all key stakeholders will have direct accept to development aid data."
   quote-author: Maxwell Mkwezalamba, Malawi Minister of Finance
   url: http://malawiaid.finance.gov.mw/
+  urlText:
   lat: -13.2483745
   lon: 34.2955468
 
@@ -134,6 +143,7 @@
   quote:
   quote-author:
   url: http://www.odamoz.org.mz/
+  urlText:
   lat: -18.6696821
   lon: 35.5273356
 
@@ -147,6 +157,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 2.0333
   lon: 45.3500
   
@@ -161,6 +172,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 7.8626845
   lon: 29.694923
 
@@ -175,6 +187,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 14.5001715
   lon: -14.4392276
 
@@ -189,6 +202,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 13.4667
   lon: 16.6000
 
@@ -203,6 +217,7 @@
   quote: ...everyone can use AMP to analyze, to see, to view, and to provide any data.
   quote-author: Tanzania Development Partner Representative
   url:
+  urlText:
   lat: -6.3728255
   lon: 34.8924826
 
@@ -217,5 +232,6 @@
   quote: We are accountable to the public, so anyone… should be able to access all of the information they need off the system.
   quote-author: Uganda Development Partner Representative
   url: http://154.72.196.70/amp/portal/
+  urlText:
   lat: 1.3681549
   lon: 32.303241

--- a/_data/poi_reach/africa.yaml
+++ b/_data/poi_reach/africa.yaml
@@ -10,7 +10,7 @@
   quote: "MapAfrica allows us to present our investments and results in a simple way, bringing us closer to the people we serve."
   quote-author: Simon Mizrahi, AfDB Director
   url: http://mapafrica.afdb.org/
-  urlText:
+  urlText: Visit Map Africa
 
 - name: Burkina Faso
   id: burkina-faso
@@ -232,6 +232,6 @@
   quote: We are accountable to the public, so anyone… should be able to access all of the information they need off the system.
   quote-author: Uganda Development Partner Representative
   url: http://154.72.196.70/amp/portal/
-  urlText:
+  urlText: Visit Uganda's Aid Management Platform
   lat: 1.3681549
   lon: 32.303241

--- a/_data/poi_reach/africa.yaml
+++ b/_data/poi_reach/africa.yaml
@@ -31,10 +31,10 @@
   id: chad
   year: 2014
   category: Aid Management Program
-  description: Chad's AMP will include geocoded aid information and a public portal, signaling committment to granular, transparent information. 
+  description: Chad's AMP will include geocoded aid information and a public portal, signaling committment to granular, transparent information.
   features:
     - Transparent aid information
-    - Vizualizing data for better decision making 
+    - Vizualizing data for better decision making
   quote:
   quote-author:
   url:
@@ -160,7 +160,7 @@
   urlText:
   lat: 2.0333
   lon: 45.3500
-  
+
 - name: South Sudan
   id: south-sudan
   year: 2010

--- a/_data/poi_reach/americas.yaml
+++ b/_data/poi_reach/americas.yaml
@@ -9,6 +9,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 4.624335
   lon: -74.063644
 
@@ -23,6 +24,7 @@
   quote: "[AMP] will directly support our efforts to become an emerging economy by 2030."
   quote-author: Government of Haiti Representative
   url: https://haiti.ampsite.net/
+  urlText:
   lat: 19.0558462
   lon: -73.0513321
 
@@ -37,6 +39,7 @@
   quote:
   quote-author:
   url: http://pgc.sre.gob.hn/
+  urlText:
   lat: 14.7503821
   lon: -86.2420082
 
@@ -50,6 +53,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 40.751985
   lon: -73.969780
 
@@ -63,5 +67,6 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 38.894598
   lon: -77.047151

--- a/_data/poi_reach/asia.yaml
+++ b/_data/poi_reach/asia.yaml
@@ -10,6 +10,7 @@
   quote:
   quote-author:
   url: http://amp.gov.md/portal/
+  urlText:
   lat: 41.2228055
   lon: 74.7387787
 
@@ -24,6 +25,7 @@
   quote:
   quote-author:
   url: http://amp.mpi.gov.la/
+  urlText:
   lat: 18.206296
   lon: 103.889022
 
@@ -38,6 +40,7 @@
   quote: "AMP gets everyone in the same room and puts information in a package."
   quote-author: Nepal Development Partner Representative
   url: http://amis.mof.gov.np/portal/
+  urlText:
   lat: 28.3974557
   lon: 84.1299978
 
@@ -52,5 +55,6 @@
   quote: "Transparency means transparency. We have nothing to hide."
   quote-author: Emilia Pires, Timor-Leste Minister of Finance
   url: https://www.aidtransparency.gov.tl/TEMPLATE/ampTemplate/gisModule/dist/index.html
+  urlText:
   lat: -8.7947508
   lon: 126.1369154

--- a/_data/poi_reach/europe.yaml
+++ b/_data/poi_reach/europe.yaml
@@ -10,7 +10,7 @@
   urlText:
   lat: 50.842856
   lon: 4.375405
-  
+
 - name: European Union
   id: eu
   year: 2014

--- a/_data/poi_reach/europe.yaml
+++ b/_data/poi_reach/europe.yaml
@@ -7,6 +7,7 @@
   quote:
   quote-author:
   url:
+  urlText:
   lat: 50.842856
   lon: 4.375405
   
@@ -21,6 +22,7 @@
   quote:
   quote-author:
   url: https://github.com/devgateway/eudevfin
+  urlText:
   lat: 49.5
   lon: 22.0
 
@@ -35,6 +37,7 @@
   quote: "…we are now more effective and more efficient because the information necessary is just one click away."
   quote-author: Development Partner Representative, Kosovo
   url: http://public.amp-mei.net/
+  urlText:
   lat: 42.5632698
   lon: 20.9020755
 
@@ -49,5 +52,6 @@
   quote:
   quote-author: Development Partner Representative, Kosovo
   url: http://amp.gov.md/portal/
+  urlText:
   lat: 46.979424
   lon: 28.3896969

--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -10,6 +10,18 @@ module Jekyll
       input.find_all{|item| item.data.key?(property) && item.data[property] == value }
     end
 
+    # Use a default value for missing variables
+    #
+    # This filter is in Liquid master, but not in Jekyll v2.4.0.
+    # https://github.com/Shopify/liquid/commit/5db1695694e1cbf12892d5dd67c7773282a669af
+    #
+    # USAGE:
+    # {{ myVar | default: 'Default value' }}
+    def default(input, default_value = "")
+      is_blank = input.respond_to?(:empty?) ? input.empty? : !input
+      is_blank ? default_value : input
+    end
+
     # Concat lists
     #
     # It only just landed in liquid, so one day we can drop this

--- a/reach.html
+++ b/reach.html
@@ -61,7 +61,7 @@ include_map: True
     {% endif %}
 
     {% if project.url %}
-      <a class="readmore" href="{{ project.url }}">Learn more</a>
+      <a class="readmore" href="{{ project.url }}">{{ project.urlText | default: 'Learn more' }}</a>
     {% endif %}
   </div>
   {% endfor %}


### PR DESCRIPTION
eg.:
![2015-04-29-000130_502x286_scrot](https://cloud.githubusercontent.com/assets/205128/7384553/5ffb3858-ee03-11e4-80e3-c6abb00347a5.png)

I couldn't find any multi-word keys in any other yaml files, so I went with camelCase for `urlText` (happy to switch to snake_case if that's preferred). I also couldn't think of a better one-word key name.

for DGTHREE-38
