### PR TITLE
Reach taxonomy fixes

### DIFF
--- a/reach.html
+++ b/reach.html
@@ -36,8 +36,7 @@ include_map: True
     <h3 class="highlighted-title">
       {% capture image_path %}images/projects/{{ project.id }}.svg{% endcapture %}
       {% image flag_small {{ image_path }} alt="Flag of {{ project.name }}" class="flag" role="img" %}
-      {{ project.name }}
-      <span> - {{project.year}}</span>
+      {{ project.name }}{% if project.year %}, <span> beginning in {{project.year}}</span>{% endif %}
     </h3>
 
     <div class="category">{{ project.category }}</div>

--- a/scripts/reach-map.js
+++ b/scripts/reach-map.js
@@ -57,7 +57,8 @@
         return function() {
           rewrite({
             h: data.name,
-            p: data.category + ' – ' + data.year + '. ' + data.description
+            p: (data.category ? (data.category + ' – ') : '') +
+              data.year + '. ' + data.description
           });
         }
       },


### PR DESCRIPTION
Adds "beginning in" and handles missing category value on the reach page.

![2015-04-29-014956_629x157_scrot](https://cloud.githubusercontent.com/assets/205128/7385387/125b1c7a-ee13-11e4-8dd5-2da8f9a5db98.png)

for ASDB-46
