### PR TITLE
Simplify Chad and Cote d'Ivoire flags

### DIFF
--- a/images/projects/chad.svg
+++ b/images/projects/chad.svg
@@ -1,30 +1,27 @@
-<svg version="1.0" id="chad" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	viewBox="5 35 150 90" enable-background="new 0 0 160 160" xml:space="preserve">
-<g>
-	<defs>
-		<rect id="SVGID_1_" x="2.489" y="35.09" width="152.84" height="89.16"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	<path clip-path="url(#SVGID_2_)" fill="#182668" d="M2.489,35.09h50.95v89.16H2.489L2.489,35.09z"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_3_" x="2.489" y="35.09" width="152.84" height="89.16"/>
-	</defs>
-	<clipPath id="SVGID_4_">
-		<use xlink:href="#SVGID_3_"  overflow="visible"/>
-	</clipPath>
-	<path clip-path="url(#SVGID_4_)" fill="#F5CD28" d="M53.44,35.09h50.946v89.16H53.44L53.44,35.09z"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_5_" x="2.489" y="35.09" width="152.84" height="89.16"/>
-	</defs>
-	<clipPath id="SVGID_6_">
-		<use xlink:href="#SVGID_5_"  overflow="visible"/>
-	</clipPath>
-	<path clip-path="url(#SVGID_6_)" fill="#C0003B" d="M104.39,35.09h50.948v89.16H104.39V35.09z"/>
-</g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 152.8475 89.160004"
+   height="89.160004"
+   width="152.8475"
+   xml:space="preserve"
+   version="1.1"
+   id="svg3689"><defs
+     id="defs3693" /><g
+     transform="matrix(1.25,0,0,-1.25,2.51,89.9125)"
+     id="g3697"><path
+       id="path3721"
+       style="fill:#182668;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m -2.008,71.93 40.758,0 0,-71.328 -40.758,0 0,71.328 z" /><path
+       id="path3735"
+       style="fill:#f5cd28;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 38.754,71.93 40.754,0 0,-71.328 -40.754,0 0,71.328 z" /><path
+       id="path3749"
+       style="fill:#c0003b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 79.512,71.93 40.758,0 0,-71.328 -40.758,0 0,71.328 z" /></g><metadata
+     id="metadata3845"><rdf:RDF><cc:Work
+         rdf:about=""><dc:title></dc:title></cc:Work></rdf:RDF></metadata></svg>

--- a/images/projects/ivory-coast.svg
+++ b/images/projects/ivory-coast.svg
@@ -1,30 +1,27 @@
-<svg version="1.0" id="ivorycoast" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="5 35 150 90" enable-background="new 0 0 160 160" xml:space="preserve">
-<g>
-	<defs>
-		<rect id="SVGID_1_" x="2.588" y="35.05" width="154.58" height="90.17"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	<path clip-path="url(#SVGID_2_)" fill="#FFFFFF" d="M2.588,35.05h154.58v90.17H2.588L2.588,35.05z"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_3_" x="2.588" y="35.05" width="154.58" height="90.17"/>
-	</defs>
-	<clipPath id="SVGID_4_">
-		<use xlink:href="#SVGID_3_"  overflow="visible"/>
-	</clipPath>
-	<path clip-path="url(#SVGID_4_)" fill="#E77C22" d="M2.588,35.05h51.53v90.17H2.588L2.588,35.05z"/>
-</g>
-<g>
-	<defs>
-		<rect id="SVGID_5_" x="2.588" y="35.05" width="154.58" height="90.17"/>
-	</defs>
-	<clipPath id="SVGID_6_">
-		<use xlink:href="#SVGID_5_"  overflow="visible"/>
-	</clipPath>
-	<path clip-path="url(#SVGID_6_)" fill="#429E61" d="M105.64,35.05h51.53v90.17h-51.53V35.05z"/>
-</g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 154.58125 90.171249"
+   height="90.171249"
+   width="154.58125"
+   xml:space="preserve"
+   version="1.1"
+   id="svg4004"><defs
+     id="defs4008" /><g
+     transform="matrix(1.25,0,0,-1.25,2.4125,89.95125)"
+     id="g4012"><path
+       id="path4036"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m -1.93,71.961 123.664,0 0,-72.137 -123.664,0 0,72.137 z" /><path
+       id="path4050"
+       style="fill:#e77c22;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m -1.93,71.961 41.223,0 0,-72.137 -41.223,0 0,72.137 z" /><path
+       id="path4064"
+       style="fill:#429e61;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 80.512,71.961 41.223,0 0,-72.137 -41.223,0 0,72.137 z" /></g><metadata
+     id="metadata4086"><rdf:RDF><cc:Work
+         rdf:about=""><dc:title></dc:title></cc:Work></rdf:RDF></metadata></svg>


### PR DESCRIPTION
so they don't break imagemagick (at least for phil)

There are more flags that don't render correctly, but at least they don't break the build.

Used a similar process as for fixing the Nepal flag: saved as PDF in inkscape, then opened that PDF with inkscape (to drop the <use> tags), then manually simplified the xml.
